### PR TITLE
fix for issue #29

### DIFF
--- a/R/ts_anom_detection.R
+++ b/R/ts_anom_detection.R
@@ -302,7 +302,7 @@ AnomalyDetectionTs <- function(x, max_anoms = 0.10, direction = "pos",
   if (e_value) {
     anoms <- data.frame(
       timestamp = all_anoms[[1]], anoms = all_anoms[[2]],
-      expected_value = seasonal_plus_trend[[2]][as.POSIXlt(seasonal_plus_trend[[1]], tz = "UTC") %in% all_anoms[[1]]],
+      expected_value = seasonal_plus_trend[[2]][as.POSIXlt(seasonal_plus_trend[[1]], tz = "UTC") %in% as.POSIXlt(all_anoms[[1]], tz="UTC")],
       stringsAsFactors = FALSE
     )
   } else {


### PR DESCRIPTION
Issue #29 (https://github.com/twitter/AnomalyDetection/issues/29) was supposedly fixed, but I was still getting errors. The comparison to find the expected value would always return FALSE if there is only a single anom at precisely midnight.